### PR TITLE
test: implemented some Offers services unit tests

### DIFF
--- a/src/test/java/ga/wawupc/api/offers/services/OfferServiceImplTest.java
+++ b/src/test/java/ga/wawupc/api/offers/services/OfferServiceImplTest.java
@@ -6,9 +6,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
+import org.mockito.internal.matchers.Null;
 import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,5 +32,6 @@ public class OfferServiceImplTest {
     when(offerRepository.findById(1L)).thenReturn(Optional.of(offer));
     Offer response = offerServiceImpl.getById(1L);
     assertEquals(1L, response.getId());
+    verify(offerRepository).findById(offer.getId());
   }
 }

--- a/src/test/java/ga/wawupc/api/offers/services/OfferServiceImplTest.java
+++ b/src/test/java/ga/wawupc/api/offers/services/OfferServiceImplTest.java
@@ -15,4 +15,9 @@ public class OfferServiceImplTest {
   @InjectMocks
   private OfferServiceImpl offerServiceImpl;
   Offer offer;
+
+  @BeforeEach
+  public void setUp(){
+    offer = new Offer(1L, "Full Stack Developer" , "https://example.com/image.jpg","We're looking for a full stack developer with experience in Java and Angular.", "$125k-$127k", true);
+  }
 }

--- a/src/test/java/ga/wawupc/api/offers/services/OfferServiceImplTest.java
+++ b/src/test/java/ga/wawupc/api/offers/services/OfferServiceImplTest.java
@@ -8,6 +8,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
 @ExtendWith(MockitoExtension.class)
 public class OfferServiceImplTest {
   @Mock
@@ -19,5 +22,12 @@ public class OfferServiceImplTest {
   @BeforeEach
   public void setUp(){
     offer = new Offer(1L, "Full Stack Developer" , "https://example.com/image.jpg","We're looking for a full stack developer with experience in Java and Angular.", "$125k-$127k", true);
+  }
+
+  @Test
+  public void FindByIdShouldReturnSingleOffer() {
+    when(offerRepository.findById(1L)).thenReturn(Optional.of(offer));
+    Offer response = offerServiceImpl.getById(1L);
+    assertEquals(1L, response.getId());
   }
 }

--- a/src/test/java/ga/wawupc/api/offers/services/OfferServiceImplTest.java
+++ b/src/test/java/ga/wawupc/api/offers/services/OfferServiceImplTest.java
@@ -1,0 +1,18 @@
+package ga.wawupc.api.offers.services;
+import ga.wawupc.api.jobs.domain.model.entity.Offer;
+import ga.wawupc.api.jobs.domain.persistence.OfferRepository;
+import ga.wawupc.api.jobs.service.OfferServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.Optional;
+@ExtendWith(MockitoExtension.class)
+public class OfferServiceImplTest {
+  @Mock
+  private OfferRepository offerRepository;
+  @InjectMocks
+  private OfferServiceImpl offerServiceImpl;
+  Offer offer;
+}

--- a/src/test/java/ga/wawupc/api/offers/services/OfferServiceImplTest.java
+++ b/src/test/java/ga/wawupc/api/offers/services/OfferServiceImplTest.java
@@ -2,15 +2,16 @@ package ga.wawupc.api.offers.services;
 import ga.wawupc.api.jobs.domain.model.entity.Offer;
 import ga.wawupc.api.jobs.domain.persistence.OfferRepository;
 import ga.wawupc.api.jobs.service.OfferServiceImpl;
+import ga.wawupc.api.shared.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
-import org.mockito.internal.matchers.Null;
 import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -33,5 +34,14 @@ public class OfferServiceImplTest {
     Offer response = offerServiceImpl.getById(1L);
     assertEquals(1L, response.getId());
     verify(offerRepository).findById(offer.getId());
+  }
+
+  @Test
+  public void FindByIdNonExistingOfferShouldThrowException(){
+    when(offerRepository.findById(offer.getId())).thenReturn(Optional.empty());
+
+    Throwable exception =
+      catchThrowable(() -> offerServiceImpl.getById(offer.getId()));
+    assertThat(exception).isInstanceOf(ResourceNotFoundException.class);
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--
Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.
https://guides.github.com/features/mastering-markdown/
-->

### What does it do

This pull request adds two test cases to the OfferServiceImplTest class in order to increase code coverage and ensure that the getById method in the OfferServiceImpl class behaves correctly.
The first test case checks that the getById method returns the expected offer when passed a valid ID, while the second test case checks that a ResourceNotFoundException is thrown when the method is passed an ID that does not correspond to an existing offer in the database. 

### Why is it needed

This is important to ensure that the method behaves correctly and provides a clear error message when a client requests an offer that does not exist in the database. By adding this test case, we can catch and handle this scenario in a more elegant and efficient way, improving the overall reliability and usability of the system.

