### PR TITLE
ci: upload artifacts during maven build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,9 +20,16 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Install dependencies
-        run: mvn install -B -V -DskipTests=true -Dmaven.javadoc.skip=true
+        run: mvn dependency:go-offline -B
       - name: Build with Maven
         run: mvn compile -B
+      - name: Package with Maven
+        run: mvn package -B -DskipTests=true
+      - name: Upload artifacts to GitHub
+        uses: actions/upload-artifact@v3
+        with:
+          name: app-artifact
+          path: target/*.jar
   tests:
     name: Tests
     runs-on: ubuntu-latest
@@ -36,7 +43,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Install dependencies
-        run: mvn install -B -V -DskipTests=true -Dmaven.javadoc.skip=true
+        run: mvn dependency:go-offline -B
       - name: Run tests
         run: mvn test -B -Dspring.profiles.active=h2
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--
Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.
https://guides.github.com/features/mastering-markdown/
-->

### What does it do

This PR adds artifact uploading to the Maven workflow. These artifacts will be used for the E2E tests in the backend (see nexgeniusupc/waw-frontend-angular#2).

### Why is it needed

During E2E tests, the artifacts will be downloaded and executed.

### Related issue(s)/PR(s)

- nexgeniusupc/waw-frontend-angular#2
